### PR TITLE
Added details about the Boost Test Adapter

### DIFF
--- a/Docs/Walkthrough.md
+++ b/Docs/Walkthrough.md
@@ -136,7 +136,7 @@ There are many ways discovery can go wrong or provide you with unexpected result
 [29/07/2018 10:34:22 Informational] ========== Discover test finished: 0 found (0:00:01,5158472) ==========
 ```
 
-- In some cases, other test adapters may interfere with Catch2 test discovery. In those cases, look in the `Tests` output for hints. Worst case you may have to disable the test adapter that is causing trouble. By the way, this is the reason a feature was added to the **Test Adapter for Catch2** to disable it via the _.runsettings_ file. So in case the reverse happens and the **Test Adapter for Catch2** interferes with another test adapter, you have an easy way to disable the **Test Adapter for Catch2** via the _.runsettings_ file.
+- In some cases, other test adapters may interfere with Catch2 test discovery. In those cases, look in the `Tests` output for hints. Worst case you may have to disable the test adapter that is causing trouble. For instance, if the output includes `Could not locate debug symbols`, that is probably output from the Boost Test Adapter, which can be disabled from the Tools...Extensions and Updates... menu item. By the way, this is the reason a feature was added to the **Test Adapter for Catch2** to disable it via the _.runsettings_ file. So in case the reverse happens and the **Test Adapter for Catch2** interferes with another test adapter, you have an easy way to disable the **Test Adapter for Catch2** via the _.runsettings_ file.
 
 ## Running tests
 


### PR DESCRIPTION
Explanation of the `Could not locate debug symbols` output from the Boost Test Adapter.