### PR TITLE
Respect environment setting when debugging

### DIFF
--- a/Libraries/Catch2Interface/Settings.cs
+++ b/Libraries/Catch2Interface/Settings.cs
@@ -12,6 +12,7 @@ Notes: None
 ** Basic Info **/
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -369,6 +370,25 @@ Class :
         }
 
         public void AddEnviromentVariables(StringDictionary dictionary)
+        {
+            if (Environment != null && dictionary != null)
+            {
+                foreach (DictionaryEntry element in Environment)
+                {
+                    var key = element.Key as string;
+                    if(dictionary.ContainsKey(key))
+                    {
+                        dictionary[key] = element.Value as string;
+                    }
+                    else
+                    {
+                        dictionary.Add(key, element.Value as string);
+                    }
+                }
+            }
+        }
+
+        public void AddEnviromentVariables(IDictionary<string, string> dictionary)
         {
             if (Environment != null && dictionary != null)
             {

--- a/Libraries/Catch2TestAdapter/TestExecutor.cs
+++ b/Libraries/Catch2TestAdapter/TestExecutor.cs
@@ -278,11 +278,13 @@ namespace Catch2TestAdapter
                 _executor.CreateTestcaseListFile(testcasegroup, caselistfilename);
 
                 LogVerbose(TestMessageLevel.Informational, "Start debug run.");
+                Dictionary<string, string> EnvironmentVariables = new Dictionary<string, string>();
+                _settings.AddEnviromentVariables(EnvironmentVariables);
                 _frameworkHandle
                     .LaunchProcessWithDebuggerAttached( testcasegroup.Source
                                                       , _executor.WorkingDirectory(testcasegroup.Source)
                                                       , _executor.GenerateCommandlineArguments_Combined_Dbg(caselistfilename)
-                                                      , null);
+                                                      , EnvironmentVariables);
 
                 // Do not process output in Debug mode
                 foreach(var test in groupedtests)
@@ -388,11 +390,13 @@ namespace Catch2TestAdapter
             if (_runContext.IsBeingDebugged)
             {
                 LogVerbose(TestMessageLevel.Informational, "Start debug run.");
+                Dictionary<string,string> EnvironmentVariables = new Dictionary<string, string>();
+                _settings.AddEnviromentVariables(EnvironmentVariables);
                 _frameworkHandle
                     .LaunchProcessWithDebuggerAttached( test.Source
                                                       , _executor.WorkingDirectory(test.Source)
                                                       , _executor.GenerateCommandlineArguments_Single_Dbg(test.DisplayName)
-                                                      , null );
+                                                      , EnvironmentVariables);
 
                 // Do not process output in Debug mode
                 result.Outcome = TestOutcome.None;


### PR DESCRIPTION
When debugging tests, the environment setting is applied to the debugged process