### PR TITLE
Recognize Catch2 v2 output xml without a name attribute

### DIFF
--- a/Libraries/Catch2Interface/XmlOutput.cs
+++ b/Libraries/Catch2Interface/XmlOutput.cs
@@ -58,7 +58,7 @@ namespace Catch2Interface
 
         public static bool IsVersion2Xml(string output)
         {
-            return output.Contains(@"<Catch name=");
+            return output.Contains(@"<Catch") && !output.Contains(@"<Catch2TestRun");
         }
 
         public static bool IsVersion3Xml(string output)


### PR DESCRIPTION
With our settings, the Catch-element does not always have any attributes.
Changed IsVersion2Xml to recognize also such input as Catch2 data.