### PR TITLE
Enable wrapping test executable with other executable

### DIFF
--- a/Docs/Settings.md
+++ b/Docs/Settings.md
@@ -8,6 +8,8 @@ In order for the **Test Adapter for Catch2** to do its job, it requires certain 
 - [`<CombinedTimeout>`](#combinedtimeout)
 - [`<DebugBreak>`](#debugbreak)
 - [`<DiscoverCommandLine>`](#discovercommandline)
+- [`<TestExecutableOverride>`](#testexecutableoverride)
+- [`<ExtraParameters>`](#extraparameters)
 - [`<DiscoverTimeout>`](#discovertimeout)
 - [`<Environment>`](#environment)
 - [`<ExecutionMode>`](#executionmode)
@@ -124,6 +126,32 @@ With the `<DiscoverCommandLine>` option you set the commandline arguments to cal
 When you use Catch2 v3, you can set the reporter to xml for improved discovery. For previous version of Catch2 the setting had no effect on the discovery output.
 
 > Default value changed in v1.5.0, and v1.8.0
+
+## TestExecutableOverride
+
+Default: "{source}"
+
+Override the name of the executable used to run the tests. The string `{source}` will be replaced by the original source executable.
+Meant for using Catch2 in non-standard ways. For example, you can wrap the execution in a custom tool. Most useful in conjuction with
+`ExtraParameters`.
+
+## ExtraParameters
+
+Default: ""
+
+This string will be concatenated to the parameter string to every execution of the test program, whether for discovery or for execution.
+Meant for using Catch2 in non-stard ways. For example, if your tests are embedded in a program that has other run modes, this parameter
+can be used to activate the catch testing mode.
+
+The string `{source}` will be replaced by the original source executable. In conjuction with `TestExecutableOverride`, this allows you
+to wrap your catch execution in custom logic.
+
+```xml
+<Catch2Adapter>
+    <TestExecutableOverride>my-catch2-wrapper</TestExecutableOverride>
+    <ExtraParameters>--source {source}</ExtraParameters>
+</Catch2Adapter>
+```
 
 ## DiscoverTimeout
 

--- a/Docs/Settings.md
+++ b/Docs/Settings.md
@@ -133,7 +133,8 @@ Default: ""
 
 Override the name of the executable used to run the tests. Meant for using Catch2 in non-standard ways.
 For example, you can wrap the execution in a custom tool. Most useful in conjuction with `ExtraParameters`.
-Supports `%ENVIRONMENT VARIABLES%`.
+Supports `%ENVIRONMENT VARIABLES%`. Path can be absolute, or relative to the `source` or any of its
+parent directories.
 
 ## ExtraParameters
 

--- a/Docs/Settings.md
+++ b/Docs/Settings.md
@@ -131,7 +131,7 @@ When you use Catch2 v3, you can set the reporter to xml for improved discovery. 
 
 Default: ""
 
-Override the name of the executable used to run the tests. Meant for using Catch2 in non-standard ways.
+Override the executable used to run the tests. Meant for using Catch2 in non-standard ways.
 For example, you can wrap the execution in a custom tool. Most useful in conjuction with `ExtraParameters`.
 Supports `%ENVIRONMENT VARIABLES%`. Path can be absolute, or relative to the `source` or any of its
 parent directories.
@@ -141,16 +141,16 @@ parent directories.
 Default: ""
 
 This string will be concatenated to the parameter string to every execution of the test program, whether for discovery or for execution.
-Meant for using Catch2 in non-stard ways. For example, if your tests are embedded in a program that has other run modes, this parameter
+Meant for using Catch2 in non-standard ways. For example, if your tests are embedded in a program that has other run modes, this parameter
 can be used to activate the catch testing mode.
 
-The string `{source}` will be replaced by the original source executable. In conjuction with `TestExecutableOverride`, this allows you
+The string `$(Source)` will be replaced by the original source executable. In conjuction with `TestExecutableOverride`, this allows you
 to wrap your catch execution in custom logic. Supports also `%ENVIRONMENT VARIABLES%`.
 
 ```xml
 <Catch2Adapter>
     <TestExecutableOverride>my-catch2-wrapper</TestExecutableOverride>
-    <ExtraParameters>--source {source}</ExtraParameters>
+    <ExtraParameters>--source $(Source)</ExtraParameters>
 </Catch2Adapter>
 ```
 

--- a/Docs/Settings.md
+++ b/Docs/Settings.md
@@ -129,11 +129,11 @@ When you use Catch2 v3, you can set the reporter to xml for improved discovery. 
 
 ## TestExecutableOverride
 
-Default: "{source}"
+Default: ""
 
-Override the name of the executable used to run the tests. The string `{source}` will be replaced by the original source executable.
-Meant for using Catch2 in non-standard ways. For example, you can wrap the execution in a custom tool. Most useful in conjuction with
-`ExtraParameters`.
+Override the name of the executable used to run the tests. Meant for using Catch2 in non-standard ways.
+For example, you can wrap the execution in a custom tool. Most useful in conjuction with `ExtraParameters`.
+Supports `%ENVIRONMENT VARIABLES%`.
 
 ## ExtraParameters
 
@@ -144,7 +144,7 @@ Meant for using Catch2 in non-stard ways. For example, if your tests are embedde
 can be used to activate the catch testing mode.
 
 The string `{source}` will be replaced by the original source executable. In conjuction with `TestExecutableOverride`, this allows you
-to wrap your catch execution in custom logic.
+to wrap your catch execution in custom logic. Supports also `%ENVIRONMENT VARIABLES%`.
 
 ```xml
 <Catch2Adapter>

--- a/Libraries/Catch2Interface/Constants.cs
+++ b/Libraries/Catch2Interface/Constants.cs
@@ -45,6 +45,8 @@ Class :
         public const string NodeName_CombinedTimeout = "CombinedTimeout";
         public const string NodeName_DebugBreak = "DebugBreak";
         public const string NodeName_DiscoverCommanline = "DiscoverCommandLine";
+        public const string NodeName_TestExecutableOverride = "TestExecutableOverride";
+        public const string NodeName_ExtraParameters = "ExtraParameters";
         public const string NodeName_DiscoverTimeout = "DiscoverTimeout";
         public const string NodeName_Environment = "Environment";
         public const string NodeName_ExecutionMode = "ExecutionMode";
@@ -65,8 +67,7 @@ Class :
         public const bool   S_DefaultDebugBreak = false;
         public const bool   S_DefaultDisabled = false;
         public const string S_DefaultDiscoverCommandline = "--verbosity high --list-tests --reporter xml *";
-        public const string S_DefaultTestExecutableOverride = "{source}";
-		public const int    S_DefaultDiscoverTimeout = 1000; // Time in milliseconds
+        public const int    S_DefaultDiscoverTimeout = 1000; // Time in milliseconds
         public const string S_DefaultExecutionModeForceSingleTagRgx = @"(?i:tafc_Single)";
         public const string S_DefaultFilenameFilter = "";    // By default give invalid value
         public const bool   S_DefaultIncludeHidden = true;

--- a/Libraries/Catch2Interface/Constants.cs
+++ b/Libraries/Catch2Interface/Constants.cs
@@ -65,7 +65,8 @@ Class :
         public const bool   S_DefaultDebugBreak = false;
         public const bool   S_DefaultDisabled = false;
         public const string S_DefaultDiscoverCommandline = "--verbosity high --list-tests --reporter xml *";
-        public const int    S_DefaultDiscoverTimeout = 1000; // Time in milliseconds
+        public const string S_DefaultTestExecutableOverride = "{source}";
+		public const int    S_DefaultDiscoverTimeout = 1000; // Time in milliseconds
         public const string S_DefaultExecutionModeForceSingleTagRgx = @"(?i:tafc_Single)";
         public const string S_DefaultFilenameFilter = "";    // By default give invalid value
         public const bool   S_DefaultIncludeHidden = true;
@@ -73,6 +74,9 @@ Class :
         public const string S_DefaultWorkingDirectory = "";
         public const int    S_DefaultStackTraceMaxLength = 80;
         public const string S_DefaultStackTracePointReplacement = ",";
+
+        // The string to replace with the source executable in ExtraParameters.
+        public const string Tag_Source = "{source}";
 
         public const ExecutionModes        S_DefaultExecutionMode = ExecutionModes.SingleTestCase;
         public const LoggingLevels         S_DefaultLoggingLevel = LoggingLevels.Normal;
@@ -87,6 +91,5 @@ Class :
         public static readonly Regex Rgx_True = new Regex(@"^(?i:true)$", RegexOptions.Singleline);
         public static readonly Regex Rgx_OnOff = new Regex(@"^(?i:on)$|^(?i:off)$", RegexOptions.Singleline);
         public static readonly Regex Rgx_On = new Regex(@"^(?i:on)$", RegexOptions.Singleline);
-
     }
 }

--- a/Libraries/Catch2Interface/Constants.cs
+++ b/Libraries/Catch2Interface/Constants.cs
@@ -77,7 +77,7 @@ Class :
         public const string S_DefaultStackTracePointReplacement = ",";
 
         // The string to replace with the source executable in ExtraParameters.
-        public const string Tag_Source = "{source}";
+        public const string Tag_Source = "$(Source)";
 
         public const ExecutionModes        S_DefaultExecutionMode = ExecutionModes.SingleTestCase;
         public const LoggingLevels         S_DefaultLoggingLevel = LoggingLevels.Normal;

--- a/Libraries/Catch2Interface/Discoverer.cs
+++ b/Libraries/Catch2Interface/Discoverer.cs
@@ -157,8 +157,8 @@ Class :
             // Retrieve test cases
             using (var process = new Process())
             {
-                process.StartInfo.FileName = source;
-                process.StartInfo.Arguments = _settings.DiscoverCommandLine;
+                process.StartInfo.FileName = _settings.GetExecutable(source);
+                process.StartInfo.Arguments = _settings.FormatExtraParameters(source) + _settings.DiscoverCommandLine;
                 process.StartInfo.CreateNoWindow = true;
                 process.StartInfo.RedirectStandardOutput = true;
                 process.StartInfo.RedirectStandardError = true;

--- a/Libraries/Catch2Interface/Executor.cs
+++ b/Libraries/Catch2Interface/Executor.cs
@@ -96,42 +96,37 @@ Class :
             }
         }
 
-        public string GetExecutableName(string source)
+        public string GenerateCommandlineArguments_Single(string source, string testname, string reportfilename)
         {
-            return source;
+            return $"{_settings.FormatExtraParameters(source)}{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes --out {"\""}{reportfilename}{"\""}";
         }
 
-        public string GenerateCommandlineArguments_Single(string testname, string reportfilename)
-        {
-            return $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes --out {"\""}{reportfilename}{"\""}";
-        }
-
-        public string GenerateCommandlineArguments_Single_Dbg(string testname)
+        public string GenerateCommandlineArguments_Single_Dbg(string source, string testname)
         {
             if (_settings.DebugBreak)
             {
-                return $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes --break";
+                return $"{_settings.FormatExtraParameters(source)}{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes --break";
             }
             else
             {
-                return $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes";
+                return $"{_settings.FormatExtraParameters(source)}{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes";
             }
         }
 
-        public string GenerateCommandlineArguments_Combined(string caselistfilename, string reportfilename)
+        public string GenerateCommandlineArguments_Combined(string source, string caselistfilename, string reportfilename)
         {
-            return $"--reporter xml --durations yes --input-file {"\""}{caselistfilename}{"\""} --out {"\""}{reportfilename}{"\""}";
+            return $"{_settings.FormatExtraParameters(source)}--reporter xml --durations yes --input-file {"\""}{caselistfilename}{"\""} --out {"\""}{reportfilename}{"\""}";
         }
 
-        public string GenerateCommandlineArguments_Combined_Dbg(string caselistfilename)
+        public string GenerateCommandlineArguments_Combined_Dbg(string source, string caselistfilename)
         {
             if (_settings.DebugBreak)
             {
-                return $"--reporter xml --durations yes --break --input-file {"\""}{caselistfilename}{"\""}";
+                return $"{_settings.FormatExtraParameters(source)}--reporter xml --durations yes --break --input-file {"\""}{caselistfilename}{"\""}";
             }
             else
             {
-                return $"--reporter xml --durations yes --input-file {"\""}{caselistfilename}{"\""}";
+                return $"{_settings.FormatExtraParameters(source)}--reporter xml --durations yes --input-file {"\""}{caselistfilename}{"\""}";
             }
         }
 
@@ -144,8 +139,8 @@ Class :
             string reportfilename = MakeReportFilename(source);
 
             var process = new Process();
-            process.StartInfo.FileName = GetExecutableName( source );
-            process.StartInfo.Arguments = GenerateCommandlineArguments_Single(testname, reportfilename);
+            process.StartInfo.FileName = _settings.GetExecutable( source );
+            process.StartInfo.Arguments = GenerateCommandlineArguments_Single(source, testname, reportfilename);
             process.StartInfo.CreateNoWindow = true;
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.UseShellExecute = false;
@@ -225,8 +220,8 @@ Class :
 
             // Run tests
             var process = new Process();
-            process.StartInfo.FileName = GetExecutableName( group.Source );
-            process.StartInfo.Arguments = GenerateCommandlineArguments_Combined(caselistfilename, reportfilename);
+            process.StartInfo.FileName = _settings.GetExecutable( group.Source );
+            process.StartInfo.Arguments = GenerateCommandlineArguments_Combined(group.Source, caselistfilename, reportfilename);
             process.StartInfo.CreateNoWindow = true;
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.UseShellExecute = false;

--- a/Libraries/Catch2Interface/Executor.cs
+++ b/Libraries/Catch2Interface/Executor.cs
@@ -96,6 +96,11 @@ Class :
             }
         }
 
+        public string GetExecutableName(string source)
+        {
+            return source;
+        }
+
         public string GenerateCommandlineArguments_Single(string testname, string reportfilename)
         {
             return $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes --out {"\""}{reportfilename}{"\""}";
@@ -139,7 +144,7 @@ Class :
             string reportfilename = MakeReportFilename(source);
 
             var process = new Process();
-            process.StartInfo.FileName = source;
+            process.StartInfo.FileName = GetExecutableName( source );
             process.StartInfo.Arguments = GenerateCommandlineArguments_Single(testname, reportfilename);
             process.StartInfo.CreateNoWindow = true;
             process.StartInfo.RedirectStandardOutput = true;
@@ -220,7 +225,7 @@ Class :
 
             // Run tests
             var process = new Process();
-            process.StartInfo.FileName = group.Source;
+            process.StartInfo.FileName = GetExecutableName( group.Source );
             process.StartInfo.Arguments = GenerateCommandlineArguments_Combined(caselistfilename, reportfilename);
             process.StartInfo.CreateNoWindow = true;
             process.StartInfo.RedirectStandardOutput = true;

--- a/Libraries/Catch2Interface/Settings.cs
+++ b/Libraries/Catch2Interface/Settings.cs
@@ -131,7 +131,7 @@ Class :
         public bool                       DebugBreak { get; set; }                     = Constants.S_DefaultDebugBreak;
         public bool                       Disabled { get; set; }                       = Constants.S_DefaultDisabled;
         public string                     DiscoverCommandLine { get; set; }            = Constants.S_DefaultDiscoverCommandline;
-        public string                     TestExecutableOverride { get; set; }         = Constants.S_DefaultTestExecutableOverride;
+        public string                     TestExecutableOverride { get; set; }         = string.Empty;
         public string                     ExtraParameters { get; set; }                = string.Empty;
         public int                        DiscoverTimeout { get; set; }                = Constants.S_DefaultDiscoverTimeout;
         public IDictionary<string,string> Environment { get; set; }
@@ -325,6 +325,16 @@ Class :
                     }
                 }
 
+                // TestExecutableOverride
+                var testexecutableoverride = node.SelectSingleNode( Constants.NodeName_TestExecutableOverride )?.FirstChild;
+                if( testexecutableoverride != null && testexecutableoverride.NodeType == XmlNodeType.Text )
+                    settings.TestExecutableOverride = testexecutableoverride.Value;
+
+                // ExtraParameters
+                var extraparameters = node.SelectSingleNode( Constants.NodeName_ExtraParameters )?.FirstChild;
+                if ( extraparameters != null && extraparameters.NodeType == XmlNodeType.Text )
+                    settings.ExtraParameters = extraparameters.Value;
+
                 // WorkingDirectory
                 var workingdir = node.SelectSingleNode(Constants.NodeName_WorkingDirectory)?.FirstChild;
                 if( workingdir != null && workingdir.NodeType == XmlNodeType.Text )
@@ -435,7 +445,7 @@ Class :
             if (String.IsNullOrEmpty(TestExecutableOverride))
                 return source;
             else
-                return TestExecutableOverride;
+                return System.Environment.ExpandEnvironmentVariables( TestExecutableOverride );
         }
 
         /// <summary>
@@ -448,7 +458,8 @@ Class :
             if (String.IsNullOrEmpty(ExtraParameters))
                 return "";
             else
-                return ExtraParameters.Replace(Constants.Tag_Source, source) + " ";
+                return System.Environment.ExpandEnvironmentVariables(
+                    ExtraParameters.Replace(Constants.Tag_Source, source) + " " );
         }
 
         #endregion // Public Methods

--- a/Libraries/Catch2Interface/Settings.cs
+++ b/Libraries/Catch2Interface/Settings.cs
@@ -460,7 +460,7 @@ Class :
                 return relativeToCWD;
 
             // Otherwise try to find it relative to the source and its parent directories.
-            for (DirectoryInfo parent = Directory.GetParent(expandedOverride); parent != null; parent = parent.Parent)
+            for (DirectoryInfo parent = Directory.GetParent(source); parent != null; parent = parent.Parent)
             {
                 // Formulate the path relative to this folder.
                 string relativeToParent = Path.Combine(parent.FullName, expandedOverride);

--- a/Libraries/Catch2Interface/Settings.cs
+++ b/Libraries/Catch2Interface/Settings.cs
@@ -483,7 +483,9 @@ Class :
                 return "";
             else
                 return System.Environment.ExpandEnvironmentVariables(
-                    ExtraParameters.Replace(Constants.Tag_Source, source) + " " );
+                    ExtraParameters
+                        .Replace(Constants.Tag_Source, source)
+                        .Replace(Constants.Tag_Source.ToLower(), source)+ " ");
         }
 
         #endregion // Public Methods

--- a/Libraries/Catch2Interface/Settings.cs
+++ b/Libraries/Catch2Interface/Settings.cs
@@ -11,6 +11,7 @@ Notes: None
 
 ** Basic Info **/
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -131,8 +132,8 @@ Class :
         public bool                       Disabled { get; set; }                       = Constants.S_DefaultDisabled;
         public string                     DiscoverCommandLine { get; set; }            = Constants.S_DefaultDiscoverCommandline;
         public string                     TestExecutableOverride { get; set; }         = Constants.S_DefaultTestExecutableOverride;
-		public string                     ExtraParameters { get; set; }                = string.Empty;
-		public int                        DiscoverTimeout { get; set; }                = Constants.S_DefaultDiscoverTimeout;
+        public string                     ExtraParameters { get; set; }                = string.Empty;
+        public int                        DiscoverTimeout { get; set; }                = Constants.S_DefaultDiscoverTimeout;
         public IDictionary<string,string> Environment { get; set; }
         public ExecutionModes             ExecutionMode { get; set; }                  = Constants.S_DefaultExecutionMode;
         public Regex                      ExecutionModeForceSingleTagRgx { get; set; } = new Regex(Constants.S_DefaultExecutionModeForceSingleTagRgx, RegexOptions.Singleline);
@@ -421,6 +422,33 @@ Class :
                 }
             }
             return envvars;
+        }
+        
+        /// <summary>
+        /// Returns the executable that should be run for tests in source.
+        /// Defaults to the source, but may be overridden.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public string GetExecutable(string source)
+        {
+            if (String.IsNullOrEmpty(TestExecutableOverride))
+                return source;
+            else
+                return TestExecutableOverride;
+        }
+
+        /// <summary>
+        /// Returns extra parameters formatted ready for inclusion in the command line.
+        /// (Empty string if there are no parameters, followed by a space if there are.)
+        /// </summary>
+        /// <returns></returns>
+        public string FormatExtraParameters(string source)
+        {
+            if (String.IsNullOrEmpty(ExtraParameters))
+                return "";
+            else
+                return ExtraParameters.Replace(Constants.Tag_Source, source) + " ";
         }
 
         #endregion // Public Methods

--- a/Libraries/Catch2Interface/Settings.cs
+++ b/Libraries/Catch2Interface/Settings.cs
@@ -130,7 +130,9 @@ Class :
         public bool                       DebugBreak { get; set; }                     = Constants.S_DefaultDebugBreak;
         public bool                       Disabled { get; set; }                       = Constants.S_DefaultDisabled;
         public string                     DiscoverCommandLine { get; set; }            = Constants.S_DefaultDiscoverCommandline;
-        public int                        DiscoverTimeout { get; set; }                = Constants.S_DefaultDiscoverTimeout;
+        public string                     TestExecutableOverride { get; set; }         = Constants.S_DefaultTestExecutableOverride;
+		public string                     ExtraParameters { get; set; }                = string.Empty;
+		public int                        DiscoverTimeout { get; set; }                = Constants.S_DefaultDiscoverTimeout;
         public IDictionary<string,string> Environment { get; set; }
         public ExecutionModes             ExecutionMode { get; set; }                  = Constants.S_DefaultExecutionMode;
         public Regex                      ExecutionModeForceSingleTagRgx { get; set; } = new Regex(Constants.S_DefaultExecutionModeForceSingleTagRgx, RegexOptions.Singleline);

--- a/Libraries/Catch2TestAdapter/TestDiscoverer.cs
+++ b/Libraries/Catch2TestAdapter/TestDiscoverer.cs
@@ -21,6 +21,7 @@ namespace Catch2TestAdapter
 {
     [DefaultExecutorUri("executor://Catch2TestExecutor")]
     [FileExtension(".exe")]
+    [FileExtension(".dll")]
     public class TestDiscoverer : ITestDiscoverer
     {
         #region Fields

--- a/Libraries/Catch2TestAdapter/TestExecutor.cs
+++ b/Libraries/Catch2TestAdapter/TestExecutor.cs
@@ -389,7 +389,7 @@ namespace Catch2TestAdapter
             {
                 LogVerbose(TestMessageLevel.Informational, "Start debug run.");
                 _frameworkHandle
-                    .LaunchProcessWithDebuggerAttached( test.Source
+                    .LaunchProcessWithDebuggerAttached( _executor.GetExecutableName(test.Source)
                                                       , _executor.WorkingDirectory(test.Source)
                                                       , _executor.GenerateCommandlineArguments_Single_Dbg(test.DisplayName)
                                                       , _settings.GetEnviromentVariablesForDebug() );

--- a/Libraries/Catch2TestAdapter/TestExecutor.cs
+++ b/Libraries/Catch2TestAdapter/TestExecutor.cs
@@ -279,9 +279,9 @@ namespace Catch2TestAdapter
 
                 LogVerbose(TestMessageLevel.Informational, "Start debug run.");
                 _frameworkHandle
-                    .LaunchProcessWithDebuggerAttached( testcasegroup.Source
+                    .LaunchProcessWithDebuggerAttached( _settings.GetExecutable(testcasegroup.Source)
                                                       , _executor.WorkingDirectory(testcasegroup.Source)
-                                                      , _executor.GenerateCommandlineArguments_Combined_Dbg(caselistfilename)
+                                                      , _executor.GenerateCommandlineArguments_Combined_Dbg(testcasegroup.Source, caselistfilename)
                                                       , _settings.GetEnviromentVariablesForDebug());
 
                 // Do not process output in Debug mode
@@ -389,9 +389,9 @@ namespace Catch2TestAdapter
             {
                 LogVerbose(TestMessageLevel.Informational, "Start debug run.");
                 _frameworkHandle
-                    .LaunchProcessWithDebuggerAttached( _executor.GetExecutableName(test.Source)
+                    .LaunchProcessWithDebuggerAttached( _settings.GetExecutable(test.Source)
                                                       , _executor.WorkingDirectory(test.Source)
-                                                      , _executor.GenerateCommandlineArguments_Single_Dbg(test.DisplayName)
+                                                      , _executor.GenerateCommandlineArguments_Single_Dbg(test.Source, test.DisplayName)
                                                       , _settings.GetEnviromentVariablesForDebug() );
 
                 // Do not process output in Debug mode

--- a/UnitTests/UT_Catch2Interface/TestExecution/SingleModeTests.cs
+++ b/UnitTests/UT_Catch2Interface/TestExecution/SingleModeTests.cs
@@ -57,6 +57,40 @@ namespace UT_Catch2Interface.TestExecution
         }
 
         [DataTestMethod]
+        [DynamicData( nameof( VersionPaths ), DynamicDataSourceType.Property )]
+        public void TestRun_TestExecutableOverride( string versionpath )
+        {
+            var source = Paths.TestExecutable_Execution(TestContext, versionpath);
+            if (string.IsNullOrEmpty( source ))
+            {
+                Assert.Fail( $"Missing test executable for {versionpath}." );
+                return;
+            }
+
+            // TestExecutableOverride is meant for wrapping the test execution
+            // with a different executable. We don't have a suitable wrapper
+            // executable, so we test the behaviour with a trick:
+            // we put the real source as the override, and pass a dummy
+            // value as the source.
+            var settings = new Settings();
+            settings.ExecutionMode = ExecutionModes.SingleTestCase;
+            settings.TestExecutableOverride = source;
+
+            // Use the executing assembly as the dummy value ensure that it
+            // is an existing file, because the executor checks that.
+            string dummySource = System.Reflection.Assembly.GetExecutingAssembly().Location;
+
+            var executor = new Executor( settings, _pathSolution, _pathTestRun );
+
+            // The run should work with the dummy source, because we overrode the
+            // test executable.
+            var result = executor.Run( "Names. abcdefghijklmnopqrstuvwxyz", dummySource );
+            Assert.AreEqual( TestOutcomes.Passed, result.Outcome );
+            Assert.AreEqual( 0, result.OverallResults.Failures );
+            Assert.AreEqual( 1, result.OverallResults.Successes );
+        }
+
+        [DataTestMethod]
         [DynamicData(nameof(VersionPaths), DynamicDataSourceType.Property)]
         public void TestRun_TestNames_Pass(string versionpath)
         {


### PR DESCRIPTION
Greetings,

We need to be able to run Catch2 tests inside MFC extension DLL:s. To do this, we have implemented a test executor application that acts as an MFC Application capable of hosting the extension DLL, then invokes a specific entry point in the DLL, which then executes all Catch tests inside.

We want to make these tests visible in Visual Studio. Our use case is very particular, but I think I managed to expand the configurability of this adapter in a fairly reasonable direction, generic enough to support our weirdness. This comes in the form
of two additional runsettings parameters:

* `TestExecutableOverride` causes the adapter to run the executable named in this setting, instead of the `source` currently being tested. The named file is searched relative to every ancestor directory of `source`. Ideally I would have made the path relative to the runsettings file, but I didn't find any way for the adapter to find out the path of the runsettings in use.
* `ExtraParameters` is prepended to every command line invocation, both for discovery and for execution. The string `$(Source)` is replaced with the source file being executed.

Together these two settings allow us to make the adapter execute our Catch DLL:s with the host executable.

It is fair enough if you don't find these changes reasonable; this is non-standard usage of Catch. But I think this flexibility would be valuable for other uses dealing with strange corner cases. Let's be honest; 90% of current C++ usage is supporting weird legacy things.