### PR TITLE
Create a configuration for generating a NuGet package

### DIFF
--- a/Libraries/Catch2.TestAdapter.nuspec
+++ b/Libraries/Catch2.TestAdapter.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Catch2.TestAdapter</id>
+    <version>$version$</version>
+    <title>Visual Studio Test Adapter for Catch2</title>
+    <authors>JohnnyHendriks</authors>
+    <owners>JohnnyHendriks</owners>
+    <projectUrl>https://github.com/JohnnyHendriks/TestAdapter_Catch2</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <description>
+        Class library containing the Visual Studio Test Adapter for Catch2
+    </description>
+    <releaseNotes></releaseNotes>
+    <copyright></copyright>
+    <tags>native catch2 test adapter</tags>
+    <dependencies>
+      <group targetFramework="native" />
+    </dependencies>
+  </metadata>
+  <files>
+    <!-- Must copy the files to the folder "native" to make the package installable in native projects.
+         The Visual Studio test window recognizes any file named *.TestAdapter.dll in a nuget package
+         as a potential adapter, not caring about the platform. See
+         https://github.com/microsoft/vstest/blob/main/docs/RFCs/0004-Adapter-Extensibility.md -->
+    <file src="Catch2TestAdapter\bin\$configuration$\Catch2.TestAdapter.dll" target="lib\native\" />
+    <file src="Catch2Interface\bin\$configuration$\Catch2Interface.dll" target="lib\native\" />
+  </files>
+</package>

--- a/Libraries/Catch2TestAdapter/Catch2TestAdapter.csproj
+++ b/Libraries/Catch2TestAdapter/Catch2TestAdapter.csproj
@@ -12,7 +12,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Catch2TestAdapter</RootNamespace>
-    <AssemblyName>Catch2TestAdapter</AssemblyName>
+    <AssemblyName>Catch2.TestAdapter</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>


### PR DESCRIPTION
I am planning to distribute this adapter internally as a nuget package. It doesn't seem you had nuget support configured in this repository, so I set it up. It took quite a lot of head banging to figure out how to convince nuget to install a package consisting of managed assemblies to a native project, so I thought I'd share my configuration in case you want to set up official nuget packages  some day.

* End assembly file name in `.TestAdapter` to make VS recognize it from a nuget package.
* Create `Catch2TestAdapter.nuspec` to configure the nuget package. I tried embedding the nuget metadata in the project, but could not get it to support the exotic combination of having .NET assemblies that are meant to be installed in a native project.

See https://github.com/microsoft/vstest/blob/main/docs/RFCs/0004-Adapter-Extensibility.md

Command to generate the package:
`nuget pack Catch2.TestAdapter.nuspec -Version 1.8.0 -p Configuration=Debug`

PS. For `.vcxproj`s VS only finds adapters mentioned in packages.config, not in `PackageReference`s, unless you apply [extra invocations](https://github.com/microsoft/react-native-windows/issues/8171).