### PR TITLE
DLL Runner

### DIFF
--- a/Docs/Settings.md
+++ b/Docs/Settings.md
@@ -8,6 +8,8 @@ In order for the **Test Adapter for Catch2** to do its job, it requires certain 
 - [`<CombinedTimeout>`](#combinedtimeout)
 - [`<DebugBreak>`](#debugbreak)
 - [`<DiscoverCommandLine>`](#discovercommandline)
+- [`<DllExecutor>`](#dllexecutor)
+- [`<DllExecutorCommandLine>`](#dllexecutorcommandline)
 - [`<DiscoverTimeout>`](#discovertimeout)
 - [`<Environment>`](#environment)
 - [`<ExecutionMode>`](#executionmode)
@@ -124,6 +126,33 @@ With the `<DiscoverCommandLine>` option you set the commandline arguments to cal
 When you use Catch2 v3, you can set the reporter to xml for improved discovery. For previous version of Catch2 the setting had no effect on the discovery output.
 
 > Default value changed in v1.5.0, and v1.8.0
+
+## DllExecutor
+
+Default: ""
+
+Used to support running tests embedded in DLL:s.
+When a test source is a DLL, this program is used to run it. The program will need to
+know how to invoke Catch2 tests inside your DLL:s, there is no standard for this.
+Supports `%ENVIRONMENT VARIABLES%`. Path can be absolute, or relative to the `source` or any of its
+parent directories.
+
+## DllExecutorCommandLine
+
+Default: "$(Source) $(CatchParameters)"
+
+The command line parameters passed to the `DllExecutor` when running tests from a DLL.
+
+The string `$(Source)` will be replaced by the original source executable.
+The string `$(CatchParameters)` will be replaced by the regular catch parameters.
+Supports `%ENVIRONMENT VARIABLES%`.
+
+```xml
+<Catch2Adapter>
+    <DllExecutor>my-catch2-wrapper</DllExecutor>
+    <DllExecutorCommandLine>--source $(Source) $(CatchParameters)</DllExecutorCommandLine>
+</Catch2Adapter>
+```
 
 ## DiscoverTimeout
 

--- a/Libraries/Catch2.TestAdapter.nuspec
+++ b/Libraries/Catch2.TestAdapter.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Catch2.TestAdapter</id>
+    <version>$version$</version>
+    <title>Visual Studio Test Adapter for Catch2</title>
+    <authors>JohnnyHendriks</authors>
+    <owners>JohnnyHendriks</owners>
+    <projectUrl>https://github.com/JohnnyHendriks/TestAdapter_Catch2</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <description>
+        Class library containing the Visual Studio Test Adapter for Catch2
+    </description>
+    <releaseNotes></releaseNotes>
+    <copyright></copyright>
+    <tags>native catch2 test adapter</tags>
+    <dependencies>
+      <group targetFramework="native" />
+    </dependencies>
+  </metadata>
+  <files>
+    <!-- Must copy the files to the folder "native" to make the package installable in native projects.
+         The Visual Studio test window recognizes any file named *.TestAdapter.dll in a nuget package
+         as a potential adapter, not caring about the platform. See
+         https://github.com/microsoft/vstest/blob/main/docs/RFCs/0004-Adapter-Extensibility.md -->
+    <file src="Catch2TestAdapter\bin\$configuration$\Catch2.TestAdapter.dll" target="lib\native\" />
+    <file src="Catch2Interface\bin\$configuration$\Catch2Interface.dll" target="lib\native\" />
+  </files>
+</package>

--- a/Libraries/Catch2Interface/Constants.cs
+++ b/Libraries/Catch2Interface/Constants.cs
@@ -45,6 +45,8 @@ Class :
         public const string NodeName_CombinedTimeout = "CombinedTimeout";
         public const string NodeName_DebugBreak = "DebugBreak";
         public const string NodeName_DiscoverCommanline = "DiscoverCommandLine";
+        public const string NodeName_DllExecutor = "DllExecutor";
+        public const string NodeName_DllExecutorCommandLine = "DllExecutorCommandLine";
         public const string NodeName_DiscoverTimeout = "DiscoverTimeout";
         public const string NodeName_Environment = "Environment";
         public const string NodeName_ExecutionMode = "ExecutionMode";
@@ -65,6 +67,7 @@ Class :
         public const bool   S_DefaultDebugBreak = false;
         public const bool   S_DefaultDisabled = false;
         public const string S_DefaultDiscoverCommandline = "--verbosity high --list-tests --reporter xml *";
+        public const string S_DefaultDllExecutorCommandLine = "$(Source) $(CatchParameters)";
         public const int    S_DefaultDiscoverTimeout = 1000; // Time in milliseconds
         public const string S_DefaultExecutionModeForceSingleTagRgx = @"(?i:tafc_Single)";
         public const string S_DefaultFilenameFilter = "";    // By default give invalid value
@@ -73,6 +76,11 @@ Class :
         public const string S_DefaultWorkingDirectory = "";
         public const int    S_DefaultStackTraceMaxLength = 80;
         public const string S_DefaultStackTracePointReplacement = ",";
+
+        // The string to replace with the source executable in DllExecutorCommandLine.
+        public const string Tag_Source = "$(Source)";
+        // The string to replace with the normal catch parameters in DllExecutorCommandLine.
+        public const string Tag_CatchParameters = "$(CatchParameters)";
 
         public const ExecutionModes        S_DefaultExecutionMode = ExecutionModes.SingleTestCase;
         public const LoggingLevels         S_DefaultLoggingLevel = LoggingLevels.Normal;

--- a/Libraries/Catch2Interface/Discoverer.cs
+++ b/Libraries/Catch2Interface/Discoverer.cs
@@ -157,8 +157,8 @@ Class :
             // Retrieve test cases
             using (var process = new Process())
             {
-                process.StartInfo.FileName = source;
-                process.StartInfo.Arguments = _settings.DiscoverCommandLine;
+                process.StartInfo.FileName = _settings.GetExecutable(source);
+                process.StartInfo.Arguments = _settings.FormatParameters(source, _settings.DiscoverCommandLine);
                 process.StartInfo.CreateNoWindow = true;
                 process.StartInfo.RedirectStandardOutput = true;
                 process.StartInfo.RedirectStandardError = true;

--- a/Libraries/Catch2Interface/Executor.cs
+++ b/Libraries/Catch2Interface/Executor.cs
@@ -96,37 +96,37 @@ Class :
             }
         }
 
-        public string GenerateCommandlineArguments_Single(string testname, string reportfilename)
+        public string GenerateCommandlineArguments_Single(string source, string testname, string reportfilename)
         {
-            return $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes --out {"\""}{reportfilename}{"\""}";
+            return _settings.FormatParameters(source, $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes --out {"\""}{reportfilename}{"\""}");
         }
 
-        public string GenerateCommandlineArguments_Single_Dbg(string testname)
+        public string GenerateCommandlineArguments_Single_Dbg(string source, string testname)
         {
             if (_settings.DebugBreak)
             {
-                return $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes --break";
+                return _settings.FormatParameters(source, $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes --break");
             }
             else
             {
-                return $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes";
+                return _settings.FormatParameters(source, $"{GenerateTestnameForCommandline(testname)} --reporter xml --durations yes");
             }
         }
 
-        public string GenerateCommandlineArguments_Combined(string caselistfilename, string reportfilename)
+        public string GenerateCommandlineArguments_Combined(string source, string caselistfilename, string reportfilename)
         {
-            return $"--reporter xml --durations yes --input-file {"\""}{caselistfilename}{"\""} --out {"\""}{reportfilename}{"\""}";
+            return _settings.FormatParameters(source, $"--reporter xml --durations yes --input-file {"\""}{caselistfilename}{"\""} --out {"\""}{reportfilename}{"\""}");
         }
 
-        public string GenerateCommandlineArguments_Combined_Dbg(string caselistfilename)
+        public string GenerateCommandlineArguments_Combined_Dbg(string source, string caselistfilename)
         {
             if (_settings.DebugBreak)
             {
-                return $"--reporter xml --durations yes --break --input-file {"\""}{caselistfilename}{"\""}";
+                return _settings.FormatParameters(source, $"--reporter xml --durations yes --break --input-file {"\""}{caselistfilename}{"\""}");
             }
             else
             {
-                return $"--reporter xml --durations yes --input-file {"\""}{caselistfilename}{"\""}";
+                return _settings.FormatParameters(source, $"--reporter xml --durations yes --input-file {"\""}{caselistfilename}{"\""}");
             }
         }
 
@@ -139,8 +139,8 @@ Class :
             string reportfilename = MakeReportFilename(source);
 
             var process = new Process();
-            process.StartInfo.FileName = source;
-            process.StartInfo.Arguments = GenerateCommandlineArguments_Single(testname, reportfilename);
+            process.StartInfo.FileName = _settings.GetExecutable(source);
+            process.StartInfo.Arguments = GenerateCommandlineArguments_Single(source, testname, reportfilename);
             process.StartInfo.CreateNoWindow = true;
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.UseShellExecute = false;
@@ -220,8 +220,8 @@ Class :
 
             // Run tests
             var process = new Process();
-            process.StartInfo.FileName = group.Source;
-            process.StartInfo.Arguments = GenerateCommandlineArguments_Combined(caselistfilename, reportfilename);
+            process.StartInfo.FileName = _settings.GetExecutable( group.Source );
+            process.StartInfo.Arguments = GenerateCommandlineArguments_Combined(group.Source, caselistfilename, reportfilename);
             process.StartInfo.CreateNoWindow = true;
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.UseShellExecute = false;

--- a/Libraries/Catch2TestAdapter/Catch2TestAdapter.csproj
+++ b/Libraries/Catch2TestAdapter/Catch2TestAdapter.csproj
@@ -12,7 +12,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Catch2TestAdapter</RootNamespace>
-    <AssemblyName>Catch2TestAdapter</AssemblyName>
+    <AssemblyName>Catch2.TestAdapter</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/Libraries/Catch2TestAdapter/TestDiscoverer.cs
+++ b/Libraries/Catch2TestAdapter/TestDiscoverer.cs
@@ -21,6 +21,7 @@ namespace Catch2TestAdapter
 {
     [DefaultExecutorUri("executor://Catch2TestExecutor")]
     [FileExtension(".exe")]
+    [FileExtension(".dll")]
     public class TestDiscoverer : ITestDiscoverer
     {
         #region Fields

--- a/Libraries/Catch2TestAdapter/TestExecutor.cs
+++ b/Libraries/Catch2TestAdapter/TestExecutor.cs
@@ -279,9 +279,9 @@ namespace Catch2TestAdapter
 
                 LogVerbose(TestMessageLevel.Informational, "Start debug run.");
                 _frameworkHandle
-                    .LaunchProcessWithDebuggerAttached( testcasegroup.Source
+                    .LaunchProcessWithDebuggerAttached( _settings.GetExecutable(testcasegroup.Source)
                                                       , _executor.WorkingDirectory(testcasegroup.Source)
-                                                      , _executor.GenerateCommandlineArguments_Combined_Dbg(caselistfilename)
+                                                      , _executor.GenerateCommandlineArguments_Combined_Dbg(testcasegroup.Source, caselistfilename)
                                                       , _settings.GetEnviromentVariablesForDebug());
 
                 // Do not process output in Debug mode
@@ -389,9 +389,9 @@ namespace Catch2TestAdapter
             {
                 LogVerbose(TestMessageLevel.Informational, "Start debug run.");
                 _frameworkHandle
-                    .LaunchProcessWithDebuggerAttached( test.Source
+                    .LaunchProcessWithDebuggerAttached( _settings.GetExecutable(test.Source)
                                                       , _executor.WorkingDirectory(test.Source)
-                                                      , _executor.GenerateCommandlineArguments_Single_Dbg(test.DisplayName)
+                                                      , _executor.GenerateCommandlineArguments_Single_Dbg(test.Source, test.DisplayName)
                                                       , _settings.GetEnviromentVariablesForDebug() );
 
                 // Do not process output in Debug mode


### PR DESCRIPTION
I feel like I wrote this message already a while back, but I can't find it anywhere, so maybe I forgot to send it? Sorry for the redundancy if I just didn't find the previous instance.

When making #63 I tried to be generic in hopes of getting the change upstream. In the discussion there, it sounds like you have your own vision of supporting the DLL use case, and won't be accepting my approach. Instead, you recommended using a private fork until the upstream supports this case. With that in view, I implemented the functionality in a less generic way, more precisely suited for our needs. This MR contains that implementation. I don't necessarily expect you to merge this, but thought it may be useful as a reference.

The idea here is to explicitly support using an executable wrapper to run the tests when the original source is a DLL file.