### PR TITLE
Skipped tests to be shown as skipped in vstest (former showing as suc…

### DIFF
--- a/Libraries/Catch2Interface/Reporter/OverallResult.cs
+++ b/Libraries/Catch2Interface/Reporter/OverallResult.cs
@@ -38,6 +38,7 @@ Class :
         public string   StdErr { get; private set; } = string.Empty;
         public string   StdOut { get; private set; } = string.Empty;
         public bool     Success { get; private set; } = false;
+        public bool Skipped { get; private set; } = false;
 
         #endregion // Properties
 
@@ -51,6 +52,12 @@ Class :
                 if(success != null && Constants.Rgx_TrueFalse.IsMatch(success))
                 {
                     Success = Constants.Rgx_True.IsMatch(success);
+                }
+
+                var skipped = node.Attributes["skips"]?.Value;
+                if (skipped != null && skipped == "1")
+                {
+                    Skipped = true;
                 }
 
                 double duration = 0.0;

--- a/Libraries/Catch2Interface/Reporter/OverallResult.cs
+++ b/Libraries/Catch2Interface/Reporter/OverallResult.cs
@@ -38,7 +38,7 @@ Class :
         public string   StdErr { get; private set; } = string.Empty;
         public string   StdOut { get; private set; } = string.Empty;
         public bool     Success { get; private set; } = false;
-        public bool Skipped { get; private set; } = false;
+        public bool     Skipped { get; private set; } = false;
 
         #endregion // Properties
 

--- a/Libraries/Catch2Interface/TestResult.cs
+++ b/Libraries/Catch2Interface/TestResult.cs
@@ -96,7 +96,7 @@ Class :
             Duration = _testcase.OverallResult.Duration;
             Name = _testcase.Name;
             Outcome = _testcase.OverallResult.Success ? TestOutcomes.Passed : TestOutcomes.Failed;
-            if(testcase.OverallResult.Skipped)
+            if(_testcase.OverallResult.Skipped)
             {
                 Outcome = TestOutcomes.Skipped;
             }

--- a/Libraries/Catch2Interface/TestResult.cs
+++ b/Libraries/Catch2Interface/TestResult.cs
@@ -96,6 +96,10 @@ Class :
             Duration = _testcase.OverallResult.Duration;
             Name = _testcase.Name;
             Outcome = _testcase.OverallResult.Success ? TestOutcomes.Passed : TestOutcomes.Failed;
+            if(testcase.OverallResult.Skipped)
+            {
+                Outcome = TestOutcomes.Skipped;
+            }
             StandardOut = _testcase.OverallResult.StdOut;
             StandardError = _testcase.OverallResult.StdErr;
 
@@ -420,6 +424,10 @@ Class :
                     _testcase = testcase;
 
                     Outcome = _testcase.OverallResult.Success ? TestOutcomes.Passed : TestOutcomes.Failed;
+                    if(_testcase.OverallResult.Skipped)
+                    {
+                        Outcome = TestOutcomes.Skipped;
+                    }
                     Duration = _testcase.OverallResult.Duration;
                     StandardOut = _testcase.OverallResult.StdOut;
                     StandardError = _testcase.OverallResult.StdErr;


### PR DESCRIPTION
The testadpater is not carry forwarding the skipped status from the catch2 reporter xml. Instead those skipped tests are shown as success in trx file. 
eg: 
```
TEST_CASE("Prototyp-ABC", "[ABC]")
{
    SKIP("Skippting this test");
    CHECK(1 == 2);   // will not be reached
}
```

With this change, the skipped tests are shown as 'Skipped' in Visual studio Test explorer and as "NotExecuted" in generated trx file.

 ` <UnitTestResult executionId="6a3c2627-d0cb-4929-80c5-1fc76c01b68f" testId="59c277a5-ecdc-f576-9efd-6e2ec64fe185" testName="Prototyp-ABC" computerName="xxxxxx" startTime="2024-10-10T10:19:39.1749244+02:00" endTime="2024-10-10T10:19:39.1749244+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6a3c2627-d0cb-4929-80c5-1fc76c01b68f">`

Open Point:

Overall result in trx file  does not show skipped tests.

` <ResultSummary outcome="Failed">
    <Counters total="4" executed="3" passed="1" failed="2" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />`